### PR TITLE
fix: 更新 alloy 和 scrutiny-collector 获取 latest tag 的方式

### DIFF
--- a/fn-grafana-alloy/build.sh
+++ b/fn-grafana-alloy/build.sh
@@ -16,8 +16,8 @@ WORKDIR="$(
 
 get_latest_version() {
   local tag
-  tag=$(curl -fsSL "https://api.github.com/repos/grafana/alloy/releases/latest" \
-    | grep '"tag_name"' | head -1 | sed 's/.*"v\([^"]*\)".*/\1/')
+  tag=$(curl -fsSL -w "%{url_effective}" -o /dev/null "https://github.com/grafana/alloy/releases/latest" \
+    | awk -F'/' '{print $NF}' | sed 's/^[v|V]//g')
   if [ -z "$tag" ]; then
     echo "ERROR: Failed to get latest version" >&2
     exit 1

--- a/fn-scrutiny-collector/build.sh
+++ b/fn-scrutiny-collector/build.sh
@@ -16,8 +16,8 @@ WORKDIR="$(
 
 get_latest_version() {
   local tag
-  tag=$(curl -fsSL "https://api.github.com/repos/Starosdev/scrutiny/releases/latest" \
-    | grep '"tag_name"' | head -1 | sed 's/.*"v\([^"]*\)".*/\1/')
+  tag=$(curl -fsSL -w "%{url_effective}" -o /dev/null "https://github.com/Starosdev/scrutiny/releases/latest" \
+    | awk -F'/' '{print $NF}' | sed 's/^[v|V]//g')
   if [ -z "$tag" ]; then
     echo "ERROR: Failed to get latest version" >&2
     exit 1


### PR DESCRIPTION
## 更新 alloy 和 scrutiny-collector 获取 latest tag 的方式

使用无 api 请求数限制的方式
- 修改为 `curl -fsSL -w "%{url_effective}" -o /dev/null "https://github.com/grafana/alloy/releases/latest" \
    | awk -F'/' '{print $NF}' | sed 's/^[v|V]//g'` 