### PR TITLE
固定 scrutiny 版本

### DIFF
--- a/fn-scrutiny-collector/build.sh
+++ b/fn-scrutiny-collector/build.sh
@@ -25,7 +25,8 @@ get_latest_version() {
   echo "$tag"
 }
 
-SCRUTINY_VERSION="${1:-$(get_latest_version)}"
+#SCRUTINY_VERSION="${1:-$(get_latest_version)}"
+SCRUTINY_VERSION="1.49.2"
 echo "Building Scrutiny Collector v${SCRUTINY_VERSION} ..."
 
 ARCHS=(x86_64 aarch64)

--- a/fn-scrutiny-collector/manifest
+++ b/fn-scrutiny-collector/manifest
@@ -1,5 +1,5 @@
 appname               = fn-scrutiny-collector
-version               = 1.34.0
+version               = 1.49.2
 display_name          = Scrutiny Collector
 desc                  = 硬盘 S.M.A.R.T 健康监控采集器，定时采集硬盘健康数据发送到 Scrutiny Web 服务
 platform              = all


### PR DESCRIPTION
[Starosdev/scrutiny] 最新 releases v1.50.0 缺少了文件，现在固定为最后一次正确构建 1.49.2

来源： https://github.com/RROrg/fn-apps/pull/26#issuecomment-4257693275